### PR TITLE
Added docker support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ wg_obfuscator
 *dump
 commit.h
 .vscode
+.wg-obfuscator.conf
+.idea/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+# Stage 1: Build
+FROM ubuntu:latest AS builder
+
+# Install necessary build tools and dependencies
+RUN apt-get update && \
+    apt-get install -y build-essential sudo git systemctl
+
+# Add the current project to the container
+COPY . /usr/src/app
+
+# Set the working directory
+WORKDIR /usr/src/app
+
+# Build the project using make
+RUN make
+
+# Install the built project into the /install directory
+RUN mkdir /install && \
+    make install
+
+# Stage 2: Runtime
+FROM ubuntu:latest
+
+# Copy installed files from builder stage
+COPY --from=builder /usr/bin/wg-obfuscator /usr/bin/wg-obfuscator
+COPY --from=builder /etc/wg-obfuscator.conf /etc/wg-obfuscator.conf
+
+# Ensure necessary permissions
+RUN chmod +x /usr/bin/wg-obfuscator
+
+# Command to start the service
+CMD ["wg-obfuscator", "-c", "/etc/wg-obfuscator.conf"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3.8'
+
+services:
+  wg-obfuscator:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - ./.wg-obfuscator.conf:/etc/wg-obfuscator.conf
+    ports:
+      - "13255:13255/udp"
+      - "13255:13255/tcp"
+    container_name: wg-obfuscator-container
+    restart: unless-stopped


### PR DESCRIPTION
Added Dockerfile and an example docker-compose file.

For ease of use, added `.wg-obfuscator.conf` (notice the dot) to gitignore. It will be useful for users that cloned the repo and need experiment with their own config without touching the example one.