### PR TITLE
fix compiler-warning about masking lower-case copy

### DIFF
--- a/masking.c
+++ b/masking.c
@@ -23,8 +23,8 @@ masking_handler_t * get_masking_handler_by_name(const char *name) {
     if (!name) return NULL;
 
     for (int i = 0; masking_handlers[i]; ++i) {
-        char handler_name_lower[sizeof(masking_handlers[i]->name)];
-        snprintf(handler_name_lower, sizeof(handler_name_lower), "%s", masking_handlers[i]->name);
+        char handler_name_lower[MASKING_HANDLER_NAME_LEN];
+        strncpy(handler_name_lower, masking_handlers[i]->name, sizeof(handler_name_lower) - 1);
         handler_name_lower[sizeof(handler_name_lower) - 1] = 0;
         for (char *p = handler_name_lower; *p; ++p) *p = tolower((unsigned char)*p);
 

--- a/masking.h
+++ b/masking.h
@@ -5,6 +5,8 @@
 #include <netinet/in.h>
 #include "wg-obfuscator.h"
 
+#define MASKING_HANDLER_NAME_LEN 32
+
 typedef ssize_t (*send_data_callback_t)(uint8_t *buffer, int length);
 
 typedef void (*masking_event_handler_t)(obfuscator_config_t *config,
@@ -32,7 +34,7 @@ typedef void (*masking_timer_handler_t)(obfuscator_config_t *config,
                                 send_data_callback_t send_to_server_callback);
 
 struct masking_handler {
-    char name[32];
+    char name[MASKING_HANDLER_NAME_LEN];
     masking_event_handler_t on_handshake_req;
     masking_data_handler_t on_data_wrap;
     masking_data_handler_t on_data_unwrap;


### PR DESCRIPTION
Fixes a minor issue with copying of the masking handlers name to lowercase.