### PR TITLE
Fix build for gcc 8

### DIFF
--- a/config.c
+++ b/config.c
@@ -291,12 +291,14 @@ static int parse_opt(const char *lname, char sname, const char *val, void *ctx)
         case 'f':
             // parse string with decimal and hexadecimal support
 #ifdef __linux__
-            long int v = strtol(val, NULL, 0);
-            if (v <= 0 || v > UINT16_MAX) {
-                log(LL_ERROR, "Invalid firewall mark: %s", val);
-                exit(EXIT_FAILURE);
+            {
+                long int v = strtol(val, NULL, 0);
+                if (v <= 0 || v > UINT16_MAX) {
+                    log(LL_ERROR, "Invalid firewall mark: %s", val);
+                    exit(EXIT_FAILURE);
+                }
+                config->fwmark = (uint16_t)v;
             }
-            config->fwmark = (uint16_t)v;
 #else
             log(LL_WARN, "Firewall mark is not supported on this platform");
 #endif


### PR DESCRIPTION
I was receiving the following error during `make`
```
gcc -O2 -Wall  -Wno-stringop-truncation -o wg-obfuscator.o -c wg-obfuscator.c
gcc -O2 -Wall  -Wno-stringop-truncation -o config.o -c config.c
config.c: In function ‘parse_opt’:
config.c:294:13: error: a label can only be part of a statement and a declaration is not a statement
             long int v = strtol(val, NULL, 0);
             ^~~~
make: *** [Makefile:97: config.o] Error 1
```
with 
```
gcc -v
Using built-in specs.
COLLECT_GCC=gcc
COLLECT_LTO_WRAPPER=/usr/lib/gcc/x86_64-linux-gnu/8/lto-wrapper
OFFLOAD_TARGET_NAMES=nvptx-none
OFFLOAD_TARGET_DEFAULT=1
Target: x86_64-linux-gnu
Configured with: ../src/configure -v --with-pkgversion='Debian 8.3.0-6' --with-bugurl=file:///usr/share/doc/gcc-8/README.Bugs --enable-languages=c,ada,c++,go,brig,d,fortran,objc,obj-c++ --prefix=/usr --with-gcc-major-version-only --program-suffix=-8 --program-prefix=x86_64-linux-gnu- --enable-shared --enable-linker-build-id --libexecdir=/usr/lib --without-included-gettext --enable-threads=posix --libdir=/usr/lib --enable-nls --enable-bootstrap --enable-clocale=gnu --enable-libstdcxx-debug --enable-libstdcxx-time=yes --with-default-libstdcxx-abi=new --enable-gnu-unique-object --disable-vtable-verify --enable-libmpx --enable-plugin --enable-default-pie --with-system-zlib --with-target-system-zlib --enable-objc-gc=auto --enable-multiarch --disable-werror --with-arch-32=i686 --with-abi=m64 --with-multilib-list=m32,m64,mx32 --enable-multilib --with-tune=generic --enable-offload-targets=nvptx-none --without-cuda-driver --enable-checking=release --build=x86_64-linux-gnu --host=x86_64-linux-gnu --target=x86_64-linux-gnu
Thread model: posix
gcc version 8.3.0 (Debian 8.3.0-6)
```

It was happening because of variable declaration inside the case clause.