### PR TITLE
Fix flake not accepting keyFile option

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -80,7 +80,7 @@
               key = mkOption {
                 type = types.nullOr types.str;
                 default = null;
-                description = "Obfuscation key (must match on both sides)";
+                description = "Obfuscation key (must match on both sides; required when keyFile is not set)";
                 example = "your_secret_key";
               };
 
@@ -203,9 +203,17 @@
               }
               {
                 assertion = all (inst:
-                  inst.enable -> (inst.key != null || inst.keyFile != null)
+                  inst.enable ->
+                    (
+                      inst.keyFile != null
+                      || (
+                        inst.key != null
+                        && builtins.stringLength inst.key >= 1
+                        && builtins.stringLength inst.key <= 255
+                      )
+                    )
                 ) (attrValues cfg.instances);
-                message = "Each enabled wg-obfuscator instance must have either 'key' or 'keyFile' set";
+                message = "Each enabled wg-obfuscator instance must have either 'keyFile' set, or 'key' set to a string of length 1–255 characters";
               }
             ];
 

--- a/flake.nix
+++ b/flake.nix
@@ -78,7 +78,8 @@
               };
 
               key = mkOption {
-                type = types.str;
+                type = types.nullOr types.str;
+                default = null;
                 description = "Obfuscation key (must match on both sides)";
                 example = "your_secret_key";
               };
@@ -202,7 +203,7 @@
               }
               {
                 assertion = all (inst:
-                  inst.enable -> (inst.key != "" || inst.keyFile != null)
+                  inst.enable -> (inst.key != null || inst.keyFile != null)
                 ) (attrValues cfg.instances);
                 message = "Each enabled wg-obfuscator instance must have either 'key' or 'keyFile' set";
               }
@@ -263,7 +264,7 @@
                       max-clients = ${toString inst.maxClients}
                       idle-timeout = ${toString inst.idleTimeout}
                       max-dummy = ${toString inst.maxDummy}
-                    '') (attrValues instances)
+                    '') instances
                   )}
                   EOF
 


### PR DESCRIPTION
Closes #46 

Had to fix a couple of minor things. Note that this does not allow using a keyFile under ~, because the systemd unit that runs the generated script has protectHome enabled. But it works well for keyfiles that are under /run/secrets, etc.